### PR TITLE
Add raw mode

### DIFF
--- a/pipit.c
+++ b/pipit.c
@@ -26,10 +26,29 @@
 #define DEFAULT_HOST "localhost"
 #define DEFAULT_PORT "8080"
 
+#include <errno.h>
 #include <getopt.h>
+#include <locale.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <termios.h>
+#include <unistd.h>
+#include <wchar.h>
+#include <wctype.h>
+
+#define CLEAR_SCREEN L"\x1b[2J"
+#define CURSOR_HOME L"\x1b[H"
+
+#define CTRL_KEY(K) (K) & 0x1f
+
+#define DIE_IF(E)    \
+    do               \
+    {                \
+        if (E)       \
+            die(#E); \
+    } while (0)
 
 /******************************************************************************/
 /* Data                                                                       */
@@ -41,7 +60,88 @@ struct
     const char *port;
     const char *filename;
     bool server;
+
+    struct termios termios;
+    wint_t key;
 } E;
+
+/******************************************************************************/
+/* Terminal                                                                   */
+/******************************************************************************/
+
+void die(const char *s)
+{
+    wprintf(CLEAR_SCREEN);
+    wprintf(CURSOR_HOME);
+
+    fwprintf(stderr, L"%s: %s\n", s, strerror(errno));
+    exit(EXIT_FAILURE);
+}
+
+void noraw(void)
+{
+    tcsetattr(STDIN_FILENO, TCSAFLUSH, &E.termios);
+}
+
+void raw(void)
+{
+    DIE_IF(tcgetattr(STDIN_FILENO, &E.termios) < 0);
+    DIE_IF(atexit(noraw) < 0);
+
+    struct termios to = E.termios;
+    to.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
+    to.c_oflag &= ~(OPOST);
+    to.c_cflag |= CS8;
+    to.c_lflag &= ~(ECHO | ICANON | IEXTEN | ISIG);
+
+    DIE_IF(tcsetattr(STDIN_FILENO, TCSAFLUSH, &to) < 0);
+}
+
+wint_t getch(void)
+{
+    wint_t key = fgetwc(stdin);
+    DIE_IF(key < 0);
+    return key;
+}
+
+/******************************************************************************/
+/* Output                                                                     */
+/******************************************************************************/
+
+void refresh(void)
+{
+    wprintf(CLEAR_SCREEN);
+    wprintf(CURSOR_HOME);
+
+    if (iswcntrl(E.key))
+    {
+        wprintf(L"%d", E.key);
+    }
+    else
+    {
+        wprintf(L"%d ('%lc')", E.key, E.key);
+    }
+}
+
+/******************************************************************************/
+/* Input                                                                      */
+/******************************************************************************/
+
+void process_input(void)
+{
+    wint_t key = getch();
+    switch (key)
+    {
+    case CTRL_KEY('d'):
+        wprintf(CLEAR_SCREEN);
+        wprintf(CURSOR_HOME);
+        exit(EXIT_SUCCESS);
+
+    default:
+        E.key = key;
+        break;
+    }
+}
 
 /******************************************************************************/
 /* Parsing                                                                    */
@@ -49,15 +149,15 @@ struct
 
 void usage(FILE *file, const char *program)
 {
-    fprintf(file, "Usage: %s [OPTION] FILENAME\n", program);
-    fprintf(file, "\n");
-    fprintf(file, "A collaborative text editor for the terminal.\n");
-    fprintf(file, "\n");
-    fprintf(file, "Options:\n");
-    fprintf(file, "     -i HOST     Host of server (default: " DEFAULT_HOST ")\n");
-    fprintf(file, "     -p PORT     Port of server (default: " DEFAULT_PORT ")\n");
-    fprintf(file, "     -s          Run as server (default: false)\n");
-    fprintf(file, "     -h          Show this help message and exit\n");
+    fwprintf(file, L"Usage: %s [OPTION] FILENAME\n", program);
+    fwprintf(file, L"\n");
+    fwprintf(file, L"A collaborative text editor for the terminal.\n");
+    fwprintf(file, L"\n");
+    fwprintf(file, L"Options:\n");
+    fwprintf(file, L"     -i HOST     Host of server (default: " DEFAULT_HOST ")\n");
+    fwprintf(file, L"     -p PORT     Port of server (default: " DEFAULT_PORT ")\n");
+    fwprintf(file, L"     -s          Run as server (default: false)\n");
+    fwprintf(file, L"     -h          Show this help message and exit\n");
 }
 
 void parse(int argc, char **argv)
@@ -98,9 +198,9 @@ void parse(int argc, char **argv)
     }
     else
     {
-        fprintf(stderr, "%s: missing operand\n", *argv);
+        fwprintf(stderr, L"%s: missing operand\n", *argv);
     more:
-        fprintf(stderr, "Try '%s -h' for more information.\n", *argv);
+        fwprintf(stderr, L"Try '%s -h' for more information.\n", *argv);
         exit(EXIT_FAILURE);
     }
 }
@@ -111,12 +211,15 @@ void parse(int argc, char **argv)
 
 int main(int argc, char **argv)
 {
+    setlocale(LC_ALL, "");
     parse(argc, argv);
+    raw();
 
-    printf("E.host = %s\n", E.host);
-    printf("E.port = %s\n", E.port);
-    printf("E.filename = %s\n", E.filename);
-    printf("E.server = %s\n", E.server ? "true" : "false");
+    while (1)
+    {
+        refresh();
+        process_input();
+    }
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This puts the terminal into **raw mode** which means that the program will receive keypresses as they are pressed, contrary to the default **cooked mode** where keypresses are buffered until after the user enters a newline. The flags were taken from [this](https://viewsourcecode.org/snaptoken/kilo/02.enteringRawMode.html) which is a very good resource.

![GordonRamsayItsRawGIF](https://user-images.githubusercontent.com/1607044/199037140-73bc57e2-eeec-4d47-b517-1612d8e0baa0.gif)
